### PR TITLE
Add title attr to hostCol to show host on hover

### DIFF
--- a/static/js/uzblmonitor.js
+++ b/static/js/uzblmonitor.js
@@ -35,6 +35,7 @@ var MonitorRow = React.createClass({
         <a href="#"
            ref="editableAlias"
            name="alias"
+           title={host}
            data-type="text"
            data-pk={host}
            data-url="/monitor/update_alias"


### PR DESCRIPTION
Currently, the only way to view a monitor's hostname if it has an alias set is to look at the HTML source code. This change adds a title attribute which will display the hostname when the user hovers their mouse over the alias.
